### PR TITLE
Check for bugs

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -268,7 +268,7 @@ class GameTestSuite {
   // 結果表示
   showResults() {
     log('\n📊 テスト結果サマリー', 'bright');
-    log('=' * 50, 'cyan');
+    log('='.repeat(50), 'cyan');
     
     log(`総テスト数: ${this.total}`, 'blue');
     log(`成功: ${this.passed}`, 'green');
@@ -283,13 +283,13 @@ class GameTestSuite {
       log('\n⚠️ いくつかのテストが失敗しました。', 'yellow');
     }
     
-    log('=' * 50, 'cyan');
+    log('='.repeat(50), 'cyan');
   }
 
   // 全テスト実行
   runAllTests() {
     log('🚀 ブロック崩しゲーム - 自動テスト開始', 'bright');
-    log('=' * 50, 'cyan');
+    log('='.repeat(50), 'cyan');
     
     this.testFileExists();
     this.testFileContents();

--- a/test.html
+++ b/test.html
@@ -141,7 +141,7 @@
         }
 
         // ボールテスト
-        if (ball && typeof ball.x === 'number' && typeof ball.y === 'number') {
+        if (Array.isArray(balls) && balls[0] && typeof balls[0].x === 'number' && typeof balls[0].y === 'number') {
           addResult('basic-results', '✅ ボール初期化正常', 'pass');
         } else {
           addResult('basic-results', '❌ ボール初期化異常', 'fail');


### PR DESCRIPTION
`run-tests.js` の `NaN` 出力と `test.html` のボール参照のバグを修正します。

`run-tests.js` で Python 風の `'=' * 50` が使われており、JS では `NaN` になるため `.repeat(50)` に置き換えました。また、`test.html` のボール検査が存在しない `ball` 変数を参照していたため `balls[0]` を使うよう修正しました。

---
<a href="https://cursor.com/background-agent?bcId=bc-81f65157-8631-4900-a998-5b7af2205ece">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81f65157-8631-4900-a998-5b7af2205ece">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

